### PR TITLE
Wrapping up various p1 Zupoll tasks

### DIFF
--- a/apps/zupoll-client/components/main/BallotPoll.tsx
+++ b/apps/zupoll-client/components/main/BallotPoll.tsx
@@ -15,7 +15,6 @@ export function BallotPoll({
   onVoted: (pollId: string, voteIdx: number) => void;
 }) {
   const totalVotes = poll.votes.reduce((a, b) => a + b, 0);
-  const maxVote = Math.max(...poll.votes);
 
   const getVoteDisplay = (a: number, b: number) => {
     if (b === 0) {
@@ -45,11 +44,7 @@ export function BallotPoll({
               percent={
                 totalVotes === 0 || canVote ? 0 : poll.votes[idx] / totalVotes
               }
-              isHighlighted={
-                finalVoteIdx === undefined
-                  ? maxVote === poll.votes[idx]
-                  : finalVoteIdx === idx
-              }
+              isHighlighted={finalVoteIdx === idx}
             />
             {canVote ? (
               <PollPreResult />

--- a/apps/zupoll-client/components/main/BallotPoll.tsx
+++ b/apps/zupoll-client/components/main/BallotPoll.tsx
@@ -5,11 +5,13 @@ export function BallotPoll({
   canVote,
   poll,
   voteIdx,
+  finalVoteIdx,
   onVoted,
 }: {
   canVote: boolean;
   poll: PollWithCounts;
   voteIdx: number | undefined;
+  finalVoteIdx: number | undefined;
   onVoted: (pollId: string, voteIdx: number) => void;
 }) {
   const totalVotes = poll.votes.reduce((a, b) => a + b, 0);
@@ -43,7 +45,11 @@ export function BallotPoll({
               percent={
                 totalVotes === 0 || canVote ? 0 : poll.votes[idx] / totalVotes
               }
-              isMax={maxVote === poll.votes[idx]}
+              isHighlighted={
+                finalVoteIdx === undefined
+                  ? maxVote === poll.votes[idx]
+                  : finalVoteIdx === idx
+              }
             />
             {canVote ? (
               <PollPreResult />
@@ -139,14 +145,17 @@ const PollOption = styled.span<{ canVote: boolean; selected: boolean }>`
   `}
 `;
 
-const PollProgressBar = styled.span<{ percent: number; isMax: boolean }>`
-  ${({ percent, isMax }) => css`
+const PollProgressBar = styled.span<{
+  percent: number;
+  isHighlighted: boolean;
+}>`
+  ${({ percent, isHighlighted }) => css`
     position: absolute;
     top: 0;
     left: 0;
     width: ${100 * percent}%;
     height: 100%;
-    background-color: ${isMax ? "#90ccf1" : "#cce5f3"};
+    background-color: ${isHighlighted ? "#90ccf1" : "#cce5f3"};
   `}
 `;
 

--- a/apps/zupoll-client/components/main/BallotScreen.tsx
+++ b/apps/zupoll-client/components/main/BallotScreen.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { listBallotPolls } from "../../src/api";
-import { useBallotVoting, votedOn } from "../../src/ballotVoting";
+import { getBallotVotes, useBallotVoting, votedOn } from "../../src/ballotVoting";
 import { useLogin } from "../../src/login";
 import { Ballot } from "../../src/prismaTypes";
 import { BallotPollResponse, PollWithCounts } from "../../src/requestTypes";
@@ -166,6 +166,7 @@ export function BallotScreen({ ballotURL }: { ballotURL: string }) {
                 canVote={canVote}
                 poll={poll}
                 voteIdx={pollToVote.get(poll.id)}
+                finalVoteIdx={getBallotVotes(ballotId)[poll.id]}
                 onVoted={onVoted}
               />
             ))}

--- a/apps/zupoll-client/components/main/CreateBallot.tsx
+++ b/apps/zupoll-client/components/main/CreateBallot.tsx
@@ -27,7 +27,7 @@ export function CreateBallot({
    */
   const [polls, setPolls] = useState<Poll[]>([
     {
-      id: "",
+      id: "0",
       body: "",
       options: [],
       ballotURL: 0,
@@ -142,7 +142,7 @@ export function CreateBallot({
                 setPolls([
                   ...polls,
                   {
-                    id: "",
+                    id: polls.length.toString(),
                     body: "",
                     options: [],
                     ballotURL: 0,

--- a/apps/zupoll-client/src/ballotVoting.ts
+++ b/apps/zupoll-client/src/ballotVoting.ts
@@ -10,6 +10,7 @@ import { voteBallot } from "./api";
 import { UserType, Vote } from "./prismaTypes";
 import {
   MultiVoteRequest,
+  MultiVoteResponse,
   MultiVoteSignal,
   PollWithCounts,
   VoteSignal,
@@ -118,8 +119,10 @@ export function useBallotVoting({
         return;
       }
 
-      await res.json();
+      const multiVotesResponse : MultiVoteResponse = await res.json();
+
       setVoted(ballotId);
+      setBallotVotes(ballotId, multiVotesResponse.userVotes)
       refresh(ballotId);
     }
 
@@ -174,15 +177,33 @@ export function votedOn(ballotId: string): boolean {
   return getVoted().includes(ballotId);
 }
 
-export function getVoted(): Array<string> {
+function getVoted(): Array<string> {
   const voted: Array<string> = JSON.parse(
     window.localStorage.getItem("voted") || "[]"
   );
   return voted;
 }
 
-export function setVoted(ballotId: string) {
+function setVoted(ballotId: string) {
   const newVoted = getVoted();
   newVoted.push(ballotId);
   window.localStorage.setItem("voted", JSON.stringify(newVoted));
+}
+
+export function getBallotVotes(ballotId: string) {
+  const allVotes = JSON.parse(
+    window.localStorage.getItem("allVotes") || "{}"
+  );
+  return allVotes[ballotId] || {};
+}
+
+function setBallotVotes(ballotId: string, userVotes: VoteSignal[]) {
+  const allVotes = JSON.parse(
+    window.localStorage.getItem("allVotes") || "{}"
+  );
+  allVotes[ballotId] = {};
+  for (const vote of userVotes) {
+    allVotes[ballotId][vote.pollId] = vote.voteIdx;
+  }
+  window.localStorage.setItem("allVotes", JSON.stringify(allVotes));
 }

--- a/apps/zupoll-client/src/requestTypes.ts
+++ b/apps/zupoll-client/src/requestTypes.ts
@@ -62,3 +62,7 @@ export type VoteSignal = {
   pollId: string;
   voteIdx: number;
 };
+
+export type MultiVoteResponse = {
+  userVotes: VoteSignal[];
+}

--- a/apps/zupoll-server/src/routing/routes/pcdRoutes.ts
+++ b/apps/zupoll-server/src/routing/routes/pcdRoutes.ts
@@ -13,8 +13,8 @@ import { verifyGroupProof } from "../../util/verify";
 import { cleanString, sendMessage } from "../../util/bot";
 
 /**
- * The endpoints in this function accepts proof (pcd) in the request.
- * It verifies the proof before proceed. So in this case no other type of auth (e.g. jwt)
+ * The endpoints in this function accepts proof (PCD) in the request. It verifies 
+ * the proof before proceed. So in this case no other type of auth (e.g. JWT)
  * is needed.
  */
 export function initPCDRoutes(
@@ -226,9 +226,10 @@ export function initPCDRoutes(
           voteIds.push(newVote.id);
         }
 
-        res.json({
-          ids: voteIds,
-        });
+        const multiVoteResponse: MultiVoteResponse = {
+          userVotes: multiVoteSignal.voteSignals
+        };
+        res.json(multiVoteResponse);
       } catch (e) {
         console.error(e);
         next(e);
@@ -273,3 +274,7 @@ export type VoteSignal = {
   pollId: string;
   voteIdx: number;
 };
+
+export type MultiVoteResponse = {
+  userVotes: VoteSignal[];
+}


### PR DESCRIPTION
Resolves #50. Stores user's votes in localStorage and reads from there when highlighting options.

Resolves #51. Checks that there are not multiple votes per poll ID.

Resolves #48. Changing the database prisma schema would require a reset of the data, as I wasn't careful with migrating the schema step by step. After trying to deal with that for a while, I decided on a jank but functional solution that didn't change the schema. On creation, the client puts the order of the polls in the ID field, and then the server stores this order in the options array. When the polls are retrieved by the client, it automatically sorts the polls and removes the extra option. It's obviously imperfect and ugly but it gets the job done.